### PR TITLE
Specify that the shell to be used on src_tinc is bash

### DIFF
--- a/src_tinc/Makefile
+++ b/src_tinc/Makefile
@@ -4,6 +4,7 @@ REQUIREMENTS := autoconf automake bash openssl tar wget
 
 PWD 		:= $(shell pwd)
 GIT_ROOT    := $(shell git rev-parse --show-toplevel)
+SHELL		:= /bin/bash
 
 # Default to a standard ndk location to error if not present
 ANDROID_NDK   ?= /opt/android-ndk


### PR DESCRIPTION
This fixes building src_tinc on make 3.81-3.82. This GNU Make issue describes the problem:

http://savannah.gnu.org/bugs/?30614

The lines like the following were failing because of make defaulting to /bin/sh:

```
    @cd tinc && autoreconf -fsi &>> $(LOG_FILE) && \
```
